### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,6 @@ services:
   php56-fpm:
     build: ./php56-fpm
     container_name: php56-fpm
-    ports:
-    - '9000:9000'
     links:
     - mysql
     - memcached
@@ -50,8 +48,6 @@ services:
   mysql:
     build: ./mysql
     container_name: mysql
-    ports:
-    - '3306:3306'
     environment:
       MYSQL_DATABASE: site
       MYSQL_USER: site
@@ -67,8 +63,6 @@ services:
   memcached:
     image: memcached:1.5-alpine
     container_name: memcached
-    ports:
-    - '11211:11211'
     entrypoint:
     - memcached
     - --memory-limit=1024m


### PR DESCRIPTION
Если порты не прописывать в docker-compose, то они все рано будут доступны внутри сети с контейнерами.
Но наружу не будут торчать, что снижает фронт атак.